### PR TITLE
chore(deps): (deps-dev): bump eslint, @eslint/js and prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",
         "@commitlint/config-conventional": "^19.7.1",
-        "@eslint/js": "^9.19.0",
+        "@eslint/js": "^9.20.0",
         "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.3.0",
-        "eslint": "^9.19.0",
+        "eslint": "^9.20.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-n": "^17.15.1",
         "eslint-plugin-prettier": "^5.2.3",
@@ -25,7 +25,7 @@
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-html-reporters": "^3.1.7",
-        "prettier": "^3.4.2"
+        "prettier": "^3.5.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6002,9 +6002,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
+      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1",
-    "@eslint/js": "^9.19.0",
+    "@eslint/js": "^9.20.0",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",
-    "eslint": "^9.19.0",
+    "eslint": "^9.20.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-n": "^17.15.1",
     "eslint-plugin-prettier": "^5.2.3",
@@ -55,7 +55,7 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-html-reporters": "^3.1.7",
-    "prettier": "^3.4.2"
+    "prettier": "^3.5.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
- bump eslint from 9.19.0 to 9.20.0
- bump @eslint/js from 9.19.0 to 9.20.0
- bump prettier from 3.4.2 to 3.5.0