### PR TITLE
chore(release): configure changelog generation and version comparison

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -33,7 +33,12 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
+    {
+      "path": "@semantic-release/changelog",
+      "changelogFile": "CHANGELOG.md",
+      "template": "./config/changelog-template.hbs",
+      "prepare": "./config/changelog-prepare.js"
+    },
     [
       "@semantic-release/git",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 > NOTE : Le format est basé sur [Keep a Changelog], et ce projet respecte [Semantic Versioning].
@@ -41,6 +43,6 @@ Tous les changements notables de ce projet seront documentés dans ce fichier.
 <!-- liens -->
 
 [Keep a Changelog]: https://keepachangelog.com/fr/1.0.0/ 'CHANGELOG Template et bonnes pratiques'
-[Semantic Versioning]: https://semver.org/lang/fr/ 'Bonnes pratique de la Gestion de Version'
+[Semantic Versioning]: https://semver.org/lang/fr/ 'Bonnes pratiques de la Gestion de Version'
 [Unreleased]: https://github.com/bdelion/weather-harvest/compare/1.0.0...develop 'Comparaison de la dernière version avec la future'
 [1.0.0]: https://github.com/bdelion/weather-harvest/releases/tag/1.0.0

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,3 +1,6 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [2, 'always', 150],
+  },
 };

--- a/config/changelog-prepare.js
+++ b/config/changelog-prepare.js
@@ -1,0 +1,10 @@
+module.exports = (releaseNotes, context) => {
+  // Définir previousVersion à partir de la version précédente
+  context.previousVersion = context.lastRelease.version || ''; // Si la dernière version n'existe pas, il sera vide
+
+  // Vérifier si c'est la première version du projet
+  context.isFirstVersion = context.nextRelease.version === '1.0.0';
+
+  // Retourner les notes de version sans modification (si vous avez une logique spécifique, vous pouvez la rajouter ici)
+  return releaseNotes;
+};

--- a/config/changelog-template.hbs
+++ b/config/changelog-template.hbs
@@ -1,0 +1,38 @@
+# Changelog > NOTE : Le format est basé sur [Keep a Changelog], et ce projet
+respecte [Semantic Versioning]. Tous les changements notables de ce projet
+seront documentés dans ce fichier. ## [Unreleased] ### Ajouté
+{{{added}}}
+
+### Modifié
+{{{changed}}}
+
+### Corrigé
+{{{fixed}}}
+
+## [{{version}}] -
+{{date}}
+
+### Ajouté
+{{{added}}}
+
+### Modifié
+{{{changed}}}
+
+### Corrigé
+{{{fixed}}}
+
+<!-- liens -->
+
+[Keep a Changelog]: https://keepachangelog.com/fr/1.0.0/ 'CHANGELOG Template et
+bonnes pratiques' [Semantic Versioning]: https://semver.org/lang/fr/ 'Bonnes
+pratiques de la Gestion de Version' [Unreleased]:
+https://github.com/USER/PROJECT/compare/{{lastRelease}}...develop 'Comparaison
+de la dernière version avec la future'
+{{#if isFirstVersion}}
+  <!-- Condition pour la première version -->
+  [{{version}}]: https://github.com/USER/PROJECT/releases/tag/{{version}}
+{{else}}
+  <!-- Pour les versions suivantes -->
+  [{{version}}]: https://github.com/bdelion/weather-harvest/compare/{{previousVersion}}...{{version}}
+  'Comparaison de la dernière version avec la future'
+{{/if}}


### PR DESCRIPTION
- Mise en place de la génération automatique du changelog avec des liens vers les versions précédentes et suivantes.
- Ajout de la logique pour gérer la première version et les versions suivantes dans le changelog.
- Configuration de `@semantic-release/changelog` avec un template Handlebars personnalisé et un fichier de préparation.